### PR TITLE
suggestion: add single-row exact match check

### DIFF
--- a/synthetic-text/synthetic-text.ipynb
+++ b/synthetic-text/synthetic-text.ipynb
@@ -994,7 +994,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that Term Co-occurrences are perfectly retained."
+    "We can see that Term Co-occurrences are perfectly retained.\n",
+    "\n",
+    "Now you might be asking yourself: if all of these characteristics are maintained, what are the chances that we'll end up with exact matches, i.e. synthetic records with the exact same `title` value as a record in the original dataset? Or even a synthetic record with the exact same values for all the columns?\n",
+    "\n",
+    "Let's start by trying to find an exact match for 1 specific synthetic `title` value:\n",
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+   "# find exact match for 1 specific synthetic title value. Copy a `title` value from a synthetic record into the `title_value` field below and run the cell to find an exact match in the original dataset\n",
+   "title_value = "Airy large double room\n",
+   "tgt.loc[tgt['title'].str.contains(title_value, case=False, na=False)]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+   "tags": []
+   },
+   "source": [
+    "Depending on your chosen value, you may or may not find an exact match. This row-by-row validation process doesn't indicate very much and, more importantly, doesn't scale very well to the 71K rows in the dataset.\n",
    ]
   },
   {


### PR DESCRIPTION
Suggestion for an extra step before the Exact Match section. I've included this in the video to aid legibility and take readers by the hand. 

@mplatzer - will leave it up to you whether you want this included in the canonical notebook version or not. feedback welcome, of course.